### PR TITLE
feat(books): Implement dynamic progress tracking on book details screen

### DIFF
--- a/app/(tabs)/(books)/book/[uri].tsx
+++ b/app/(tabs)/(books)/book/[uri].tsx
@@ -48,6 +48,14 @@ const BookDetails = () => {
         setLoading(false)
     }, [uri, navigator])
 
+    const handleReadBook = () => {
+        book?.updateLastRead()
+        router.push({
+            pathname: `/reader/[uri]`,
+            params: {uri: uri as string}
+        })
+    }
+
 
     if(loading) return <Text>Loading...</Text>
 
@@ -80,25 +88,30 @@ const BookDetails = () => {
                     <Text className="text-center mt-8 line-clamp-2 font-lato-bold text-3xl">
                         {book?.title}
                     </Text>
+                    {metadata?.subtitle &&( <Text className="text-center mt-2 line-clamp-2 font-lato-light text-lg text-slate-400 ">
+                        {metadata?.subtitle}
+                    </Text>)}
                     <Text className="text-center mt-4 font-body text-xl text-secondary-100">
                         {book?.creator}
                     </Text>
                 {/*  progress indicator  */}
-                    <View className="w-7/12 h-[4px] rounded-full bg-slate-300 mx-auto mt-4">
-                        <View className="bg-background-dark h-1 rounded-full origin-left w-[24%]"></View>
-                    </View>
-                    <Text className="text-center mt-2 text-typography-500">24% completed</Text>
+                    {book && book.progress > 0 && (
+                        <>
+                            <View className="w-7/12 h-[4px] rounded-full bg-slate-300 mx-auto mt-4">
+                                <View
+                                    className="bg-background-dark h-1 rounded-full"
+                                    style={{ width: `${book.progress * 100}%` }}
+                                ></View>
+                            </View>
+                            <Text className="text-center mt-2 text-typography-500">{`${Math.round(book.progress * 100)}% completed`}</Text>
+                        </>
+                    )}
                 </View>
 
                       <View className="my-8">
                           <View className="mx-auto p-4 bg-amber-900 w-1/2 rounded-full">
                               <View className="mx-auto">
-                                  <TouchableOpacity className="flex-row items justify-center gap-4" onPress={() => {
-                                    router.push({
-                                        pathname: `/reader/[uri]`,
-                                        params: {uri: uri as string}
-                                    })
-                                  }}>
+                                  <TouchableOpacity className="flex-row items justify-center gap-4" onPress={handleReadBook}>
                                       <Text className="text-white font-lato-bold text-xl">Read Book</Text>
                                       <Feather name="book-open" size={24} color={colors.light} />
                                   </TouchableOpacity>

--- a/app/(tabs)/(books)/index.tsx
+++ b/app/(tabs)/(books)/index.tsx
@@ -30,9 +30,9 @@ const Library = () => {
         filteredBooks, setFilteredBooks,
     } = useLibraryStore();
 
-    useLayoutEffect(() => {
-        setFilteredBooks(books)
-    }, );
+    // useEffect(() => {
+    //     setFilteredBooks(books)
+    // }, [books]);
 
     const handleSearch = (text: string) => {
         if (text.trim().length == 0) {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,15 +8,11 @@ export default function Index() {
 
   
   return (
-    <SafeAreaView className='mx-8'>
+    <SafeAreaView className='mx-8 bg-white'>
       <View>
           <Text className="text-blue-600">List of Books</Text>
       </View>
-
-       {/*<Button onPress={() => fetchGoogleBooksMetadata()}>*/}
-       {/*    <ButtonText >Do something Here</ButtonText>*/}
-       {/*</Button>*/}
-
+        <Text>Stuff Here</Text>
       <View>
       </View>
     </SafeAreaView>

--- a/zustand/libraryStore.ts
+++ b/zustand/libraryStore.ts
@@ -36,8 +36,9 @@ export const startLibrarySync = () => {
     // 2. Subscribe to the observable
     const subscription = booksObservable.subscribe((latestBooks: Book[]) => {
         // This callback fires immediately with current data, and again every time data changes
-        console.log(`WatermelonDB detected ${latestBooks.length} books. Updating store.`);
+        // console.log(`WatermelonDB detected ${latestBooks.length} books. Updating store.`);
         useLibraryStore.getState().setBooks(latestBooks);
+        useLibraryStore.getState().setFilteredBooks(latestBooks);
     });
 
     // Return the unsubscribe function so we can clean up the listener later


### PR DESCRIPTION
This commit introduces dynamic progress tracking for books, replacing the previously hardcoded percentage.

Key changes include:
- The `BookDetails` screen now fetches and displays the reading progress from the `Book` model.
- A progress bar and percentage text are rendered dynamically based on the `progress` field (a value from 0 to 1).
- The progress indicator is conditionally rendered, only appearing if progress is greater than zero, which provides a cleaner UI for unread books.